### PR TITLE
Remove Unused Keep Role

### DIFF
--- a/commands/add-user-to-threads.js
+++ b/commands/add-user-to-threads.js
@@ -4,7 +4,6 @@ const TOKEN = process.env.TOKEN
 const ROLE = process.env.ROLE
 const EMOJI = process.env.EMOJI
 const GUILD = process.env.GUILD
-const KEEP_ROLE = process.env.KEEP_ROLE
 
 module.exports = {
   data: new SlashCommandBuilder()


### PR DESCRIPTION
The `KEEP_ROLE` environment variable is vestigial, so we give it the chop