### PR TITLE
Standup Reminder Date Bug

### DIFF
--- a/cron/standup-reminder.js
+++ b/cron/standup-reminder.js
@@ -15,15 +15,14 @@ module.exports = {
       const channels = await guild.channels.fetch()
       const standupChannel = channels.find(channel => channel.name === "standups")
       const threads = await standupChannel.threads.fetch()
-      const now = moment()
 
-      let mondayDate = now.subtract(1, 'days')
+      let mondayDate = moment().subtract(1, 'days')
       const mondayThreadName = `${mondayDate.format('YYYY-MM-DD')} Standup`
       const mondayThread = threads.threads.find(t => t.name === mondayThreadName)
       const mondayThreadLink = mondayThread ? threadUrl(mondayThread) : ""
       const missingFromMonday = await missingStandups(client, mondayThread)
 
-      let fridayDate = now.subtract(4, 'days')
+      let fridayDate = moment().subtract(4, 'days')
       const fridayThreadName = `${fridayDate.format('YYYY-MM-DD')} EOW Standup`
       const fridayThread = threads.threads.find(t => t.name === fridayThreadName)
       const fridayThreadLink = fridayThread ? threadUrl(fridayThread) : ""

--- a/cron/utils/index.js
+++ b/cron/utils/index.js
@@ -16,7 +16,7 @@ module.exports = {
     const messages = await thread.messages.fetch()
     const messageAuthorMap = messages.reduce((authors, message) => Object.assign(authors, {[message.author.id]: true}), {})
     return Object.keys(threadMemberMap)
-      .filter(memberId => !messageAuthorMap[memberId])
+      .filter(memberId => !messageAuthorMap[memberId] && memberId !== client.user.id)
       .map(memberId => threadMemberMap[memberId])
       .sort()
   }


### PR DESCRIPTION
We were getting log output that looked like:
```
data:    index.js:2403911 - Successfully registered application commands.
data:    index.js:2403911 - bishop/cron/utils/index.js:8
data:    index.js:2403911 -     const members = await thread.members.fetch()
data:    index.js:2403911 -                                  ^
data:    index.js:2403911 - TypeError: Cannot read properties of undefined (reading 'members')
data:    index.js:2403911 -     at missingStandups (bishop/cron/utils/index.js:8:34)
data:    index.js:2403911 -     at CronJob.<anonymous> (bishop/cron/standup-reminder.js:30:39)
data:    index.js:2403911 -     at runMicrotasks (<anonymous>)
data:    index.js:2403911 -     at processTicksAndRejections (node:internal/process/task_queues:96:5)
data:    index.js:2403911 - {"level":"error","message":"Forever detected script exited with code: 1"}
data:    index.js:2403911 - {"level":"error","message":"Script restart attempt #1"}
```
and the standup reminders weren't posting. Digging in a little, it's because:

```
      let fridayDate = now.subtract(4, 'days')
      const fridayThreadName = `${fridayDate.format('YYYY-MM-DD')} EOW Standup`
      const fridayThread = threads.threads.find(t => t.name === fridayThreadName)
```

was producing `undefined` for `fridayThread` in `standup-reminder.js`. It was doing this because I was under the mistaken impression that `moment.subtract` was immutable (returned a new moment but left the original alone) rather than mutable. By subtracting 1 to get the monday date, and 4 to get the friday date, the friday date would be *5* behind, rather than 4.

The fix is to create a new moment for each subtraction rather than reusing a moment.