### PR TITLE
On-Call Engineer

### DIFF
--- a/commands/on-call.js
+++ b/commands/on-call.js
@@ -1,10 +1,5 @@
 const { SlashCommandBuilder } = require('@discordjs/builders');
-const { read, write } = require('../storage')
-
-const TOKEN = process.env.TOKEN
-const ROLE = process.env.ROLE
-const EMOJI = process.env.EMOJI
-const GUILD = process.env.GUILD
+const { write } = require('../storage')
 
 module.exports = {
   data: new SlashCommandBuilder()

--- a/commands/on-call.js
+++ b/commands/on-call.js
@@ -1,0 +1,25 @@
+const { SlashCommandBuilder } = require('@discordjs/builders');
+const { read, write } = require('../storage')
+
+const TOKEN = process.env.TOKEN
+const ROLE = process.env.ROLE
+const EMOJI = process.env.EMOJI
+const GUILD = process.env.GUILD
+
+module.exports = {
+  data: new SlashCommandBuilder()
+  .setName('set-on-call')
+  .setDescription('Set the On-Call Engineer')
+  .addUserOption(option => 
+    option.setName('user')
+    .setDescription('the user')
+    .setRequired(true)
+  ),
+
+  async execute(interaction, client) {
+    const user = interaction.options.getUser('user')
+    await write('on-call-user', user.id)
+
+    interaction.reply('Done!')
+  },
+}

--- a/cron/ask-for-on-call.js
+++ b/cron/ask-for-on-call.js
@@ -1,0 +1,31 @@
+const GUILD = process.env.GUILD
+
+const { read } = require('../storage')
+
+module.exports = {
+  schedule: '30 1 * * 1',
+  timezone: 'America/New_York',
+  execute(client) {
+    return async () => {
+      const guild = await client.guilds.fetch(GUILD)
+      const channels = await guild.channels.fetch()
+      const channel = channels.find(channel => channel.name === "keep")
+      const thread = channel.threads.cache
+        .find(thread => thread.name === 'On-call rotation')
+
+      if (!thread) {
+        return
+      }
+
+      const onCall = await read('on-call-user')
+      if (!onCall) {
+        return
+      }
+
+      thread.send(
+        `<@${onCall}>, Please tell me who the next person on-call is by ` +
+        "using the `/set-on-call` command"
+      )
+    }
+  }
+}

--- a/scripts/mainnet-alert-threads.js
+++ b/scripts/mainnet-alert-threads.js
@@ -1,0 +1,36 @@
+const moment = require('moment')
+
+const { read } = require('../storage')
+
+module.exports = {
+  trigger: 'messageCreate',
+  execute(client) {
+    return async (message) => {
+      if (!message.author.bot) {
+        return
+      }
+
+      if (message.author.id === client.user.id) {
+        return
+      }
+
+      const channel = await client.channels.fetch(message.channelId)
+      if (channel.name !== "mainnet-alerts") {
+        return
+      }
+
+      const onCall = await read('on-call-user')
+      if (!onCall) {
+        return
+      }
+
+      const threadName = `${moment().utc().format('YYYY-MM-DD HH:mm')} Alert`
+      const thread = await message.startThread({
+        name: threadName,
+        reason: "Alert"
+      })
+
+      thread.send(`🔔🔔 <@${onCall}> 🔔🔔, There is a mainnet alert!`)
+    }
+  },
+}


### PR DESCRIPTION
Now that we have an on-call schedule, we can build some discord automation around it.

New functionality:

+ A `/set-on-call` command

<img width="391" alt="image" src="https://github.com/thesis/bishop/assets/1045160/d248dd30-0428-4b26-8999-c6716647db47">

+ A weekly reminder (same time as monday standup) for the on-call engineer to set the next one

<img width="754" alt="image" src="https://github.com/thesis/bishop/assets/1045160/2f2049be-58a0-4820-bc22-04a4da02277b">

+ Automatic thread creation for alerts in `#mainnet-alerts`

<img width="568" alt="image" src="https://github.com/thesis/bishop/assets/1045160/f40dba78-c02e-4a44-a6b0-08bfac05a46f">

<img width="420" alt="image" src="https://github.com/thesis/bishop/assets/1045160/6c6f91ab-4dad-4817-867f-5a60171dc197">
